### PR TITLE
Prevents duplicate waitlist earlier-slot notifications

### DIFF
--- a/includes/Bookings.php
+++ b/includes/Bookings.php
@@ -14,6 +14,9 @@ class Bookings
     const SLOTS_OPTION = 'rrze_appointment_booked_slots';
     const META_OPTION  = 'rrze_appointment_booked_slots_meta';
 
+    private const WAITLIST_NOTIFIED_SLOTS_KEY = 'waitlist_notified_slots';
+    private const WAITLIST_LOCK_PREFIX        = 'rrze_appointment_waitlist_lock_';
+
     private static function isPastSlot(string $slot): bool
     {
         [$datePart, $timePart] = array_pad(explode(' ', $slot, 2), 2, '');
@@ -127,7 +130,7 @@ class Bookings
             unset($allMeta[$slot]);
             update_option(self::META_OPTION, $allMeta, false);
 
-            // Notify waitlisted bookers who have a later appointment for the same person
+            // Notify waitlisted bookers who have a later appointment for the same person.
             self::notifyWaitlist($slot, $meta, $allMeta);
 
             return true;
@@ -145,9 +148,9 @@ class Bookings
     private static function notifyWaitlist(string $cancelledSlot, array $cancelledMeta, array $allMeta): void
     {
         try {
-            $cancelledDate    = explode(' ', $cancelledSlot)[0] ?? '';
+            $cancelledDate     = explode(' ', $cancelledSlot)[0] ?? '';
             $cancelledPersonId = (int) ($cancelledMeta['person_id'] ?? 0);
-            $today            = date('Y-m-d');
+            $today             = current_time('Y-m-d');
 
             if (!$cancelledDate || $cancelledDate < $today) return;
 
@@ -158,7 +161,7 @@ class Bookings
                 if ($bookedPersonId !== $cancelledPersonId) continue;
 
                 $bookedDate = explode(' ', $bookedSlot)[0] ?? '';
-                if (!$bookedDate || $bookedDate <= $cancelledDate) continue;
+                if (!$bookedDate || $cancelledSlot >= $bookedSlot) continue;
                 if ($bookedDate < $today) continue;
 
                 $bookerEmail = $bookedMeta['booker_email'] ?? '';
@@ -171,65 +174,177 @@ class Bookings
         }
     }
 
-    private static function sendWaitlistNotification(string $cancelledSlot, array $cancelledMeta, string $bookedSlot, array $bookedMeta): void
+    private static function sendWaitlistNotification(string $availableSlot, array $newSlotMeta, string $bookedSlot, array $bookedMeta): void
     {
-        self::sendWaitlistNotificationStatic($cancelledSlot, $cancelledMeta, $bookedSlot, $bookedMeta);
+        self::sendWaitlistNotificationStatic($availableSlot, $newSlotMeta, $bookedSlot, $bookedMeta);
     }
 
-    public static function sendWaitlistNotificationStatic(string $cancelledSlot, array $newSlotMeta, string $bookedSlot, array $bookedMeta): void
+    /**
+     * Sends an earlier-slot notification once per distinct slot.
+     *
+     * Previously sent slots are stored inside the existing booking metadata.
+     * Older bookings do not have that field and are handled as not yet notified,
+     * so no migration is required.
+     */
+    public static function sendWaitlistNotificationStatic(string $availableSlot, array $newSlotMeta, string $bookedSlot, array $bookedMeta): bool
     {
-        [$cancelledDate, $cancelledTime] = array_pad(explode(' ', $cancelledSlot, 2), 2, '');
-        [$cancelledStart, $cancelledEnd] = array_pad(explode('-', $cancelledTime, 2), 2, '');
-        [$bookedDate, $bookedTime]       = array_pad(explode(' ', $bookedSlot, 2), 2, '');
-        [$bookedStart, $bookedEnd]       = array_pad(explode('-', $bookedTime, 2), 2, '');
-
-        $bookerEmail = $bookedMeta['booker_email'] ?? '';
-        $bookerName  = $bookedMeta['booker_name']  ?? '';
-        $title       = $cancelledMeta['title']     ?? $bookedMeta['title'] ?? '';
-        $location    = $cancelledMeta['location']  ?? '';
-        $tplId       = (int) ($bookedMeta['tpl_id'] ?? 0);
-
-        $personId = (int) ($cancelledMeta['person_id'] ?? 0);
-        $pName    = '';
-        if ($personId > 0) {
-            $pTitle  = (string) get_post_meta($personId, 'person_honorificPrefix', true);
-            $pGiven  = (string) get_post_meta($personId, 'person_givenName', true);
-            $pFamily = (string) get_post_meta($personId, 'person_familyName', true);
-            $pName   = trim(implode(' ', array_filter([$pTitle, $pGiven, $pFamily])));
+        $allMeta = (array) get_option(self::META_OPTION, []);
+        if (isset($allMeta[$bookedSlot]) && is_array($allMeta[$bookedSlot])) {
+            $bookedMeta = array_merge($bookedMeta, $allMeta[$bookedSlot]);
         }
 
-        $vars = [
-            '[title]'        => $title,
-            '[date]'         => date_i18n(get_option('date_format'), strtotime($cancelledDate)),
-            '[time]'         => $cancelledStart . ' – ' . $cancelledEnd,
-            '[current_date]' => date_i18n(get_option('date_format'), strtotime($bookedDate)),
-            '[current_time]' => $bookedStart . ' – ' . $bookedEnd,
-            '[location]'     => $location ?: '–',
-            '[person_name]'  => $pName ?: '–',
-            '[name]'         => $bookerName ?: __('there', 'rrze-appointment'),
-            '[email]'        => $bookerEmail ?: '–',
-            '[imprint_link]' => TokenManager::imprintUrl(),
-            '[post_link]'    => esc_url_raw($bookedMeta['post_link'] ?? home_url('/')),
-        ];
-
-        $tpl = $tplId > 0 ? (MailTemplatePost::getTemplateForType($tplId, 'waitlist_earlier_slot') ?? []) : [];
-        $def = MailTemplatePost::getDefault('waitlist_earlier_slot');
-
-        $bodyTpl     = !empty($tpl['body']) ? $tpl['body'] : $def['body'];
-        $bodyHtmlTpl = !empty($tpl['body_html']) ? $tpl['body_html'] : $def['body_html'];
-
-        if (strpos($bodyTpl, '[imprint_link]') === false) {
-            $bodyTpl .= "\n\n" . __('Imprint', 'rrze-appointment') . ": [imprint_link]";
-        }
-        if (strpos($bodyHtmlTpl, '[imprint_link]') === false) {
-            $bodyHtmlTpl .= '<p><a href="[imprint_link]">' . __('Imprint', 'rrze-appointment') . '</a></p>';
+        if (!self::shouldSendWaitlistNotification($availableSlot, $bookedSlot, $bookedMeta)) {
+            return false;
         }
 
-        $subject = Settings::renderTemplate(!empty($tpl['subject']) ? $tpl['subject'] : $def['subject'], $vars);
-        $plain   = Settings::renderTemplate($bodyTpl, $vars);
-        $html    = Settings::renderTemplate($bodyHtmlTpl, $vars);
+        $lockOption = self::acquireWaitlistNotificationLock($bookedSlot);
+        if ($lockOption === '') {
+            return false;
+        }
 
-        Settings::sendMail($bookerEmail, $subject, $plain, MailTemplate::wrap($html, $subject));
+        try {
+            // Re-check after acquiring the lock in case another request sent a
+            // notification while this request was waiting.
+            $allMeta = (array) get_option(self::META_OPTION, []);
+            if (!isset($allMeta[$bookedSlot]) || !is_array($allMeta[$bookedSlot])) {
+                return false;
+            }
+            $bookedMeta = array_merge($bookedMeta, $allMeta[$bookedSlot]);
+            if (!self::shouldSendWaitlistNotification($availableSlot, $bookedSlot, $bookedMeta)) {
+                return false;
+            }
+
+            [$availableDate, $availableTime] = array_pad(explode(' ', $availableSlot, 2), 2, '');
+            [$availableStart, $availableEnd] = array_pad(explode('-', $availableTime, 2), 2, '');
+            [$bookedDate, $bookedTime]       = array_pad(explode(' ', $bookedSlot, 2), 2, '');
+            [$bookedStart, $bookedEnd]       = array_pad(explode('-', $bookedTime, 2), 2, '');
+
+            $bookerEmail = sanitize_email((string) ($bookedMeta['booker_email'] ?? ''));
+            $bookerName  = $bookedMeta['booker_name']  ?? '';
+            $title       = $newSlotMeta['title']       ?? $bookedMeta['title'] ?? '';
+            $location    = $newSlotMeta['location']    ?? '';
+            $tplId       = (int) ($bookedMeta['tpl_id'] ?? 0);
+
+            $personId = (int) ($newSlotMeta['person_id'] ?? 0);
+            $pName    = '';
+            if ($personId > 0) {
+                $pTitle  = (string) get_post_meta($personId, 'person_honorificPrefix', true);
+                $pGiven  = (string) get_post_meta($personId, 'person_givenName', true);
+                $pFamily = (string) get_post_meta($personId, 'person_familyName', true);
+                $pName   = trim(implode(' ', array_filter([$pTitle, $pGiven, $pFamily])));
+            }
+
+            $vars = [
+                '[title]'        => $title,
+                '[date]'         => date_i18n(get_option('date_format'), strtotime($availableDate)),
+                '[time]'         => $availableStart . ' – ' . $availableEnd,
+                '[current_date]' => date_i18n(get_option('date_format'), strtotime($bookedDate)),
+                '[current_time]' => $bookedStart . ' – ' . $bookedEnd,
+                '[location]'     => $location ?: '–',
+                '[person_name]'  => $pName ?: '–',
+                '[name]'         => $bookerName ?: __('there', 'rrze-appointment'),
+                '[email]'        => $bookerEmail ?: '–',
+                '[imprint_link]' => TokenManager::imprintUrl(),
+                '[post_link]'    => esc_url_raw($bookedMeta['post_link'] ?? home_url('/')),
+            ];
+
+            $tpl = $tplId > 0 ? (MailTemplatePost::getTemplateForType($tplId, 'waitlist_earlier_slot') ?? []) : [];
+            $def = MailTemplatePost::getDefault('waitlist_earlier_slot');
+
+            $bodyTpl     = !empty($tpl['body']) ? $tpl['body'] : $def['body'];
+            $bodyHtmlTpl = !empty($tpl['body_html']) ? $tpl['body_html'] : $def['body_html'];
+
+            if (strpos($bodyTpl, '[imprint_link]') === false) {
+                $bodyTpl .= "\n\n" . __('Imprint', 'rrze-appointment') . ": [imprint_link]";
+            }
+            if (strpos($bodyHtmlTpl, '[imprint_link]') === false) {
+                $bodyHtmlTpl .= '<p><a href="[imprint_link]">' . __('Imprint', 'rrze-appointment') . '</a></p>';
+            }
+
+            $subject = Settings::renderTemplate(!empty($tpl['subject']) ? $tpl['subject'] : $def['subject'], $vars);
+            $plain   = Settings::renderTemplate($bodyTpl, $vars);
+            $html    = Settings::renderTemplate($bodyHtmlTpl, $vars);
+
+            if (!Settings::sendMail($bookerEmail, $subject, $plain, MailTemplate::wrap($html, $subject))) {
+                return false;
+            }
+
+            self::rememberWaitlistNotification($bookedSlot, $availableSlot);
+            return true;
+        } finally {
+            delete_option($lockOption);
+        }
+    }
+
+    private static function shouldSendWaitlistNotification(string $availableSlot, string $bookedSlot, array $bookedMeta): bool
+    {
+        if (empty($bookedMeta['booker_waitlist'])) {
+            return false;
+        }
+
+        if (sanitize_email((string) ($bookedMeta['booker_email'] ?? '')) === '') {
+            return false;
+        }
+
+        // Slot strings use a sortable "Y-m-d H:i-H:i" format.
+        if ($availableSlot === '' || $availableSlot >= $bookedSlot) {
+            return false;
+        }
+
+        return !in_array($availableSlot, self::getWaitlistNotifiedSlots($bookedMeta), true);
+    }
+
+    private static function acquireWaitlistNotificationLock(string $bookedSlot): string
+    {
+        $option = self::WAITLIST_LOCK_PREFIX . md5($bookedSlot);
+        $now    = time();
+
+        if (add_option($option, $now, '', false)) {
+            return $option;
+        }
+
+        $createdAt = (int) get_option($option, 0);
+        if ($createdAt > 0 && $createdAt < $now - 300) {
+            delete_option($option);
+            if (add_option($option, $now, '', false)) {
+                return $option;
+            }
+        }
+
+        return '';
+    }
+
+    private static function rememberWaitlistNotification(string $bookedSlot, string $availableSlot): void
+    {
+        $allMeta = (array) get_option(self::META_OPTION, []);
+        if (!isset($allMeta[$bookedSlot]) || !is_array($allMeta[$bookedSlot])) {
+            return;
+        }
+
+        $notifiedSlots = self::getWaitlistNotifiedSlots($allMeta[$bookedSlot]);
+        if (!in_array($availableSlot, $notifiedSlots, true)) {
+            $notifiedSlots[] = $availableSlot;
+            $allMeta[$bookedSlot][self::WAITLIST_NOTIFIED_SLOTS_KEY] = $notifiedSlots;
+            unset($allMeta[$bookedSlot]['waitlist_notified_slot']);
+            update_option(self::META_OPTION, $allMeta, false);
+        }
+    }
+
+    private static function getWaitlistNotifiedSlots(array $bookedMeta): array
+    {
+        $notifiedSlots = $bookedMeta[self::WAITLIST_NOTIFIED_SLOTS_KEY] ?? [];
+        if (!is_array($notifiedSlots)) {
+            $notifiedSlots = [];
+        }
+
+        // Accept the scalar watermark written by the first deduplication
+        // implementation so deployments can update without losing history.
+        $legacyNotifiedSlot = (string) ($bookedMeta['waitlist_notified_slot'] ?? '');
+        if ($legacyNotifiedSlot !== '') {
+            $notifiedSlots[] = $legacyNotifiedSlot;
+        }
+
+        return array_values(array_unique(array_filter($notifiedSlots, 'is_string')));
     }
 
     private static function sendCancellationMail(string $slot, array $meta): void

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -151,7 +151,7 @@ class Main
         add_action('template_redirect', [$this, 'handleConfirm']);
         add_action('template_redirect', [$this, 'handleCancel']);
         add_action('rrze_appointment_expire_pending', ['RRZE\Appointment\TokenManager', 'expirePending']);
-        add_action('save_post', [$this, 'handleSavePost'], 10, 2);
+        add_action('post_updated', [$this, 'handlePostUpdated'], 10, 3);
         add_action('rest_api_init', [$this, 'registerRestRoutes']);
     }
 
@@ -768,6 +768,7 @@ class Main
                 'booker_name' => $bookerName,
                 'booker_message' => $bookerMsg,
                 'booker_waitlist' => $bookerWaitlist,
+                'waitlist_notified_slots' => [],
                 'tpl_id' => $tplId,
                 'post_link' => $postLink,
             ];
@@ -996,15 +997,17 @@ class Main
             wp_die(esc_html($e->getMessage()), '', ['response' => 500]);
         }
     }
-    public function handleSavePost(int $postId, \WP_Post $post): void
+    public function handlePostUpdated(int $postId, \WP_Post $postAfter, \WP_Post $postBefore): void
     {
         if (wp_is_post_revision($postId) || wp_is_post_autosave($postId))
             return;
-        if (!has_blocks($post->post_content))
+        if ($postAfter->post_status !== 'publish' || !has_blocks($postAfter->post_content))
             return;
 
-        $today = date('Y-m-d');
-        $allMeta = (array) get_option(Bookings::META_OPTION, []);
+        $today       = current_time('Y-m-d');
+        $allMeta     = (array) get_option(Bookings::META_OPTION, []);
+        $bookedSlots = (array) get_option(Bookings::SLOTS_OPTION, []);
+        $bookedSet   = array_flip($bookedSlots);
 
         // Collect all waitlisted bookings grouped by person_id
         $waitlisted = []; // person_id => [ [slot, meta], ... ]
@@ -1021,38 +1024,48 @@ class Main
         if (empty($waitlisted))
             return;
 
-        $blocks = parse_blocks($post->post_content);
-        foreach ($blocks as $block) {
-            if (($block['blockName'] ?? '') !== 'rrze/appointment')
+        $previousSlotsByPerson = [];
+        if ($postBefore->post_status === 'publish' && has_blocks($postBefore->post_content)) {
+            $previousSlotsByPerson = $this->collectAppointmentSlots($postBefore->post_content);
+        }
+
+        $currentSlotsByPerson = $this->collectAppointmentSlots($postAfter->post_content);
+
+        foreach ($waitlisted as $personId => $entries) {
+            if (empty($currentSlotsByPerson[$personId]))
                 continue;
 
-            $attrs = $block['attrs'] ?? [];
-            $personId = (int) ($attrs['personId'] ?? 0);
-            if (!isset($waitlisted[$personId]))
+            // Only slots introduced by this update became newly available.
+            // Slots that were already free when a booking was made are present
+            // in both snapshots and therefore never trigger a notification.
+            $addedSlots = array_diff_key(
+                $currentSlotsByPerson[$personId],
+                $previousSlotsByPerson[$personId] ?? []
+            );
+            $addedSlots = array_filter(
+                $addedSlots,
+                fn($attrs, $slot) => !isset($bookedSet[$slot]) && explode(' ', $slot)[0] >= $today,
+                ARRAY_FILTER_USE_BOTH
+            );
+            if (empty($addedSlots))
                 continue;
 
-            $newSlots = SlotGenerator::fromAttributes($attrs);
-            if (empty($newSlots))
-                continue;
-
-            // Only future slots that are not already booked
-            $bookedSlots = (array) get_option(Bookings::SLOTS_OPTION, []);
-            $bookedSet = array_flip($bookedSlots);
-            $newSlots = array_filter($newSlots, fn($s) => !isset($bookedSet[$s]) && explode(' ', $s)[0] >= $today);
-
-            foreach ($waitlisted[$personId] as $entry) {
+            foreach ($entries as $entry) {
                 $bookedSlot = $entry['slot'];
                 $bookedMeta = $entry['meta'];
-                $bookedDate = explode(' ', $bookedSlot)[0];
 
-                // Find new slots that are earlier than the booked slot
-                $earlier = array_filter($newSlots, fn($s) => $s < $bookedSlot);
+                // Find the single earliest newly available slot before the booking.
+                $earlier = array_filter(
+                    array_keys($addedSlots),
+                    fn($slot) => $slot < $bookedSlot
+                );
                 if (empty($earlier))
                     continue;
 
+                $earliest = (string) min($earlier);
                 Bookings::sendWaitlistNotificationStatic(
-                    (string) min($earlier), // earliest new slot
-                    $attrs,
+                    $earliest,
+                    $addedSlots[$earliest],
                     $bookedSlot,
                     $bookedMeta
                 );
@@ -1060,5 +1073,29 @@ class Main
         }
     }
 
-}
+    private function collectAppointmentSlots(string $postContent): array
+    {
+        $slotsByPerson = [];
+        $this->collectAppointmentSlotsFromBlocks(parse_blocks($postContent), $slotsByPerson);
+        return $slotsByPerson;
+    }
 
+    private function collectAppointmentSlotsFromBlocks(array $blocks, array &$slotsByPerson): void
+    {
+        foreach ($blocks as $block) {
+            if (($block['blockName'] ?? '') === 'rrze/appointment') {
+                $attrs    = $block['attrs'] ?? [];
+                $personId = (int) ($attrs['personId'] ?? 0);
+
+                foreach (SlotGenerator::fromAttributes($attrs) as $slot) {
+                    $slotsByPerson[$personId][$slot] = $attrs;
+                }
+            }
+
+            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+                $this->collectAppointmentSlotsFromBlocks($block['innerBlocks'], $slotsByPerson);
+            }
+        }
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-appointment",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Plugin for creating and maintaining appointments. Usable as a block.",
   "author": {
     "name": "RRZE Webteam",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: appointments, calendar, booking
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.4.7
+Stable tag: 1.4.8
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://github.com/RRZE-Webteam/rrze-appointment

--- a/rrze-appointment.php
+++ b/rrze-appointment.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name:        RRZE Appointment
 Plugin URI:         https://github.com/RRZE-Webteam/rrze-appointment
-Version:            1.4.7
+Version:            1.4.8
 Description:        Appointments the easy way.
 Author:             RRZE Webteam
 Author URI:         https://www.wp.rrze.fau.de/


### PR DESCRIPTION
Addresses an issue where waitlisted bookers could receive multiple notifications for the same newly available earlier slot.

*   Introduces a mechanism to track and store previously notified slots for each booking, ensuring each unique earlier slot is communicated only once.
*   Adds a locking system to prevent race conditions when sending notifications, ensuring reliable delivery.
*   Refines the logic for detecting newly available slots during post updates, ensuring notifications are only triggered for genuinely new openings.
*   Updates the post update hook to leverage richer post change context.
*   Standardizes date and slot comparisons for increased accuracy.